### PR TITLE
Handling multiple UIGestureRecognizer

### DIFF
--- a/StyledPageControlDemo/PageControlDemo/StyledPageControl.h
+++ b/StyledPageControlDemo/PageControlDemo/StyledPageControl.h
@@ -46,7 +46,7 @@ typedef enum
     PageControlStyleStrokedSquare = 6,
 } PageControlStyle;
 
-@interface StyledPageControl : UIControl
+@interface StyledPageControl : UIControl <UIGestureRecognizerDelegate>
 @property (nonatomic) UIColor *coreNormalColor, *coreSelectedColor;
 @property (nonatomic) UIColor *strokeNormalColor, *strokeSelectedColor;
 @property (nonatomic, assign) int currentPage, numberOfPages;

--- a/StyledPageControlDemo/PageControlDemo/StyledPageControl.m
+++ b/StyledPageControlDemo/PageControlDemo/StyledPageControl.m
@@ -67,6 +67,7 @@
 	_pageControlStyle = PageControlStyleDefault;
 	
 	UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onTapped:)];
+    tapGestureRecognizer.delegate = self;
 	[self addGestureRecognizer:tapGestureRecognizer];
 }
 
@@ -392,6 +393,13 @@
         aSelectedThumbImage = self.selectedThumbImage;
     
     return aSelectedThumbImage;
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return YES;
 }
 
 @end


### PR DESCRIPTION
I used this control in one of my apps and I had the issue when more than one UIGestureRecognizer where added to a view with the same superview. I fixed by adding the StyledPageControl as a delegate for the UITapGestureRecognizer which simulated the event UIControlEventValueChanged. It is just easy as return YES when it conflicts with another UIGestureRecognizer. 

Hope it helps.
Miguel
